### PR TITLE
Build static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1.13.4-alpine
 
+ENV CGO_ENABLED=0
+
 COPY . /go/src/github.com/sensiblecodeio/https-redirect
 RUN go install -v github.com/sensiblecodeio/https-redirect


### PR DESCRIPTION
Something must have changed between the old version of Alpine used and
the current, as changed in a2d0975c9ab01bee02071be16bc15bc302c9025a.

The Docker-based build (`make build`) went from:

(previously)
```
https-redirect: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, with debug_info, not stripped
```

to

(now)
```
https-redirect: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-, not stripped
```

This binary doesn't run under Ubuntu 18.04 LTS as it can't find the
interpreter.

Instead, build a static binary to avoid this entirely. This is in line
with how hookbot and hanoverd are built.

With this commit and `make build`

```
https-redirect: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```