### PR TITLE
Fix branch syntax in ci-build.yml

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      master
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
This worked, but is now YAML compliant.