### PR TITLE
Update to Go 1.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-alpine
+FROM golang:1.18.2-alpine
 
 ENV CGO_ENABLED=0
 
@@ -6,4 +6,4 @@ WORKDIR /go/src/github.com/sensiblecodeio/https-redirect
 
 COPY . .
 
-RUN go install -v
+RUN go install -v -buildvcs=false

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sensiblecodeio/https-redirect
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Use `-buildvcs=false` for now to remove requirement for Git.
We can revisit this later.